### PR TITLE
add rewards distributor

### DIFF
--- a/contracts/YDVRewardsDistributor.sol
+++ b/contracts/YDVRewardsDistributor.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.2;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract YDVRewardsDistributor is AccessControl, Ownable {
+    using SafeERC20 for IERC20;
+    using Address for address;
+
+    IERC20 public rewardToken;
+    address[] public ydvs;
+    bytes32 public constant YDV_REWARDS = keccak256("YDV_REWARDS");
+    
+    constructor(address _rally) public {
+        rewardToken = IERC20(_rally);
+        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    }
+
+    function transferReward(uint256 _amount) external {
+        require (hasRole(YDV_REWARDS, msg.sender), "only ydv rewards");
+        rewardToken.safeTransfer(msg.sender, _amount);
+    }
+
+    function addYDV(address _ydv) external onlyOwner {
+        grantRole(YDV_REWARDS, _ydv);
+        ydvs.push(_ydv);
+    }
+
+    function ydvsLength() external view returns (uint256) {
+        return ydvs.length;
+    }
+}

--- a/contracts/YieldDelegatingVaultStorage.sol
+++ b/contracts/YieldDelegatingVaultStorage.sol
@@ -2,10 +2,12 @@
 pragma solidity ^0.6.2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./YDVRewardsDistributor.sol";
 
 contract YieldDelegatingVaultStorage {
     address public controller;
     address public vault;
+    YDVRewardsDistributor rewards;
     IERC20 public rally;
     address public treasury;
     IERC20 public token;

--- a/migrations/4_deploy_ydvs.js
+++ b/migrations/4_deploy_ydvs.js
@@ -1,7 +1,10 @@
 const YieldDelegatingVault = artifacts.require("YieldDelegatingVault");
 const RallyToken = artifacts.require("RallyToken");
+const YDVRewardsDistributor = artifacts.require("YDVRewardsDistributor");
 
-module.exports = async function(deployer) {
+module.exports = async function(deployer, network, accounts) {
+  await deployer.deploy(YDVRewardsDistributor, RallyToken.address);
+
   let controller = process.env.CONTROLLER;
   let treasury = process.env.TREASURY;
   let yusdc_address = "0x597ad1e0c13bfe8025993d9e79c69e1c0233522e"; //yearn usdc vault
@@ -9,14 +12,17 @@ module.exports = async function(deployer) {
   console.log("controller = " + controller);
   console.log("treasury = " + treasury);
 
-  await deployer.deploy(
+  let ydv = await deployer.deploy(
     YieldDelegatingVault,
     controller,
     yusdc_address,
-    RallyToken.address,
+    YDVRewardsDistributor.address,
     treasury,
     "9000", //out of 10000
     "100000000000000", //global deposit cap
     "100000000000" //per deposit cap
   ); //proxy into yearn USDC vault
+
+  let rewards = new web3.eth.Contract(YDVRewardsDistributor.abi, YDVRewardsDistributor.address);
+  rewards.methods.addYDV(ydv.address).send({from:accounts[0]});
 };

--- a/migrations/5_deploy_st.js
+++ b/migrations/5_deploy_st.js
@@ -2,7 +2,7 @@ const  SampleToken = artifacts.require("SampleToken");
 const  SampleVault = artifacts.require("SampleVault");
 const  RallyToken  = artifacts.require("RallyToken");
 const  YDV         = artifacts.require("YieldDelegatingVault");
-
+const YDVRewardsDistributor = artifacts.require("YDVRewardsDistributor");
 
 module.exports = async (deployer, network, accounts) => {
   await Promise.all ([deploySampleVault(deployer, network, accounts)]);
@@ -24,15 +24,18 @@ async function deploySampleVault (deployer, network, accounts) {
     await st.methods.mint(accounts[0], web3.utils.toBN(10**3).mul(web3.utils.toBN(10**18)).mul(web3.utils.toBN(250)).toString()).send({from: accounts[0]}); //load up some tokens in a test account
 
 
-    await deployer.deploy(
+    let ydv = await deployer.deploy(
       YDV,
       controller,
       sv.options.address,
-      RallyToken.address,
+      YDVRewardsDistributor.address,
       treasury,
       "9000", //out of 10000
       "100000000000000000000000000", //global deposit cap
       "100000000000000000000000" //per deposit cap
     );
+
+    let rewards = new web3.eth.Contract(YDVRewardsDistributor.abi, YDVRewardsDistributor.address);
+    rewards.methods.addYDV(ydv.address).send({from:accounts[0]});
   }
 }


### PR DESCRIPTION
create a single rewards distributor responsible for the entire pool of rewards. individual ydvs withdraw from this pool when allocating reward tokens. additionally, distributor serves as a single contract with which all YDVs capable of distributing rewards are registered